### PR TITLE
Create __init__ for using PyCrush as a submodule in a project

### DIFF
--- a/__init__
+++ b/__init__
@@ -1,0 +1,1 @@
+from pycrush import *


### PR DESCRIPTION
Otherwise you'd need to use `from PyCrush import pycrush`.
